### PR TITLE
Add support for short lived authentication tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ jobs:
     conductor:
         name: Private Packagist Conductor
         runs-on: "ubuntu-latest"
-        env:
-            COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
         steps:
             - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,11 @@ inputs:
 runs:
     using: "composite"
     steps:
-        - run: echo "::add-mask::$CONDUCTOR_TOKEN"
+        - run: |
+            CONDUCTOR_TOKEN=$(jq -r '.client_payload.composerAuthentication.token' $GITHUB_EVENT_PATH)
+            echo "::add-mask::$CONDUCTOR_TOKEN"
           if: ${{ github.event.client_payload.composerAuthentication.type != 'none' }}
           shell: "bash"
-          env:
-            CONDUCTOR_TOKEN: ${{ github.event.client_payload.composerAuthentication.token }}
 
         - name: "Validate GitHub action version"
           shell: "bash"

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,12 @@ inputs:
 runs:
     using: "composite"
     steps:
+        - run: echo "::add-mask::$CONDUCTOR_TOKEN"
+          if: ${{ github.event.client_payload.composerAuthentication.type != 'none' }}
+          shell: "bash"
+          env:
+            CONDUCTOR_TOKEN: ${{ github.event.client_payload.composerAuthentication.token }}
+
         - name: "Validate GitHub action version"
           shell: "bash"
           run: "${GITHUB_ACTION_PATH}/bin/ci_version_check.sh ${{ github.event.client_payload.requirements.minimumCiActionVersion }} 1.0.0"
@@ -23,6 +29,11 @@ runs:
         - name: "Validate Composer version"
           shell: "bash"
           run: "${GITHUB_ACTION_PATH}/bin/composer_version_check.sh ${{ github.event.client_payload.requirements.minimumComposerVersion }}"
+
+        - name: Configure Composer Authentication
+          shell: "bash"
+          if: ${{ github.event.client_payload.composerAuthentication.type == 'environment' }}
+          run: echo 'COMPOSER_AUTH=${{ github.event.client_payload.composerAuthentication.environment }}' >> "$GITHUB_ENV"
 
         - name: Install dependencies
           uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0


### PR DESCRIPTION
Covers the following two cases:
* a project/package that uses Private Packagist and has team package access configured -> should use the short-lived token to configure Composer auth
* a project/package that doesn't use Private Packagist -> should skip auth setup

Can be used/tested by using the branch directly in your GitHub action and running a task.
```
      - name: "Running Conductor"
        uses: packagist/conductor-github-action@conductor-short-lived-auth-token-authentication
```