### PR TITLE
Don't push branch if there are no changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
 
         - name: Store number of changed files
           id: number_of_changed_files
-          run: echo "COUNT=$(git --no-pager diff --name-only HEAD~ | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
+          run: echo "COUNT=$(git --no-pager diff --name-only $GITHUB_SHA | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
           shell: bash
 
         - name: Push branch

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,7 @@ runs:
         - name: Push branch
           run: git push origin $BRANCH --force
           shell: bash
+          if: ${{ steps.number_of_changed_files.outputs.COUNT != 0 }}
           env:
               BRANCH: ${{ github.event.client_payload.branch }}
 


### PR DESCRIPTION
For instance, for the `composer update nothing` run, no branch should be pushed.

### What this PR changes
* Triggering a task that runs `composer update nothing` will no longer push a branch
* Triggering a task that runs `composer update nothing` will no longer error with `fatal: ambiguous argument 'HEAD~': unknown revision or path not in the working tree.`