### PR TITLE
Git: add option to skip git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ For example:
       file_pattern: "composer.*"
 ```
 
+#### skip_git_hooks
+
+The `skip_git_hooks` input parameter allows you to disable any git hooks that get installed as part of the GitHub Action
+e.g. during composer install or update.
+
+For example:
+
+```yaml
+- uses: packagist/conductor-github-action
+  with:
+    skip_git_hooks: "true"
+```
+
 ## Copyright and License
 
 The  GitHub Action is licensed under the MIT License.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
         description: The file pattern used for `git add`. For example `composer.*`
         default: '.'
         required: false
+    skip_git_hooks:
+        description: Skip any git hooks that get installed as part of the GitHub Action e.g. during composer install or update.
+        default: 'false'
+        required: false
 
 runs:
     using: "composite"
@@ -44,6 +48,11 @@ runs:
           run: "${{ github.event.client_payload.updateCommand.plain }}"
           shell: bash
           working-directory: "${{ github.event.client_payload.workingDirectory }}"
+
+        - name: Uninstall git hooks
+          if: ${{ inputs.skip_git_hooks != 'false' }}
+          run: "rm -rf .git/hooks"
+          shell: "bash"
 
         - name: Create branch
           run: git checkout -b $BRANCH


### PR DESCRIPTION
### What this PR changes
* A new config option is added to delete `.git/hooks` and therefore disable any installed git hooks.

User the following snippet to disable your hooks and verify
```
            - uses: packagist/conductor-github-action@commit-no-verify
              with:
                skip_git_hooks: 'true'
```