### PR TITLE
Temporarily disable security blocking for initial setup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,13 @@ inputs:
 runs:
     using: "composite"
     steps:
+        # Temporary workaround to make sure you can set up Conductor for
+        # the first time. The CI verification job runs "composer update nothing"
+        # which fails if your composer.lock contains any versions with
+        # known security issues in Composer >=2.9.0
+        - name: Set security blocking environment variable
+          shell: "bash"
+          run: echo "COMPOSER_NO_SECURITY_BLOCKING=${{ github.event.client_payload.branch == 'conductor-nothing' && 1 || 0 }}" >> $GITHUB_ENV
         - name: Set Conductor version
           shell: "bash"
           run: echo "CONDUCTOR_ACTION_VERSION=1.5.2" >> $GITHUB_ENV


### PR DESCRIPTION
Temporary workaround to make sure you can set up Conductor for the first time. The CI verification job runs `composer update nothing` which fails if your composer.lock contains any versions with known security issues in Composer >=2.9.0. 

### Test instructions

1. Have a project that currently requires a version with known security issue in composer.lock. (`symfony/http-foundationsymfony/http-foundation v7.3.1` for example)
2. Set up Conductor and run the CI verification task
3. Using v1 action, it should fail
4. Use this branch and make sure the task now succeeds