### PR TITLE
Branch check: also allow legacy branches starting with private-packagist-updates

### DIFF
--- a/bin/branch_name_check.sh
+++ b/bin/branch_name_check.sh
@@ -3,11 +3,12 @@ set -euo pipefail
 
 BRANCH="${1:?branch name required}"
 
-# Require every Conductor-managed branch to start with the literal prefix
-# "conductor" and contain only characters that are safe inside a git refspec.
-BRANCH_RE='^conductor[A-Za-z0-9._/-]*$'
+# Require every Conductor-managed branch to start with one of the allowed
+# prefixes ("conductor" or the legacy "private-packagist-updates") and contain
+# only characters that are safe inside a git refspec.
+BRANCH_RE='^(conductor|private-packagist-updates)[A-Za-z0-9._/-]*$'
 
 if [[ ! "${BRANCH}" =~ ${BRANCH_RE} ]]; then
-    echo "::error ::branch '${BRANCH}' is not allowed; must start with 'conductor' and contain only [A-Za-z0-9._/-]"
+    echo "::error ::branch '${BRANCH}' is not allowed; must start with 'conductor' or 'private-packagist-updates' and contain only [A-Za-z0-9._/-]"
     exit 1
 fi


### PR DESCRIPTION
Older projects where we reschedule the nothing task currently fail because the nothing task has a branch name prefix starting with `private-packagist-updates/`